### PR TITLE
Update Dependencies via Dependable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,20 +6,27 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    multi_json (1.3.6)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.2)
-    simplecov (0.6.4)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.5.3)
-    simplecov-html (0.5.3)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    json (2.0.3)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
 
 PLATFORMS
   ruby
@@ -28,3 +35,6 @@ DEPENDENCIES
   rspec
   simplecov
   yarlisp!
+
+BUNDLED WITH
+   1.13.7


### PR DESCRIPTION
Implements the following updates:

Ruby dependency updates















Ruby sub-dependency updates

gem: diff-lcs
old_version: 1.1.3
new_version: 1.3
source: https://github.com/halostatue/diff-lcs/

gem: simplecov-html
old_version: 0.5.3
new_version: 0.10.0

gem: rspec-core
old_version: 2.11.1
new_version: 3.5.4
source: https://github.com/rspec/rspec-core

gem: rspec-expectations
old_version: 2.11.2
new_version: 3.5.0
source: https://github.com/rspec/rspec-expectations

gem: rspec-mocks
old_version: 2.11.2
new_version: 3.5.0
source: https://github.com/rspec/rspec-mocks

gem: simplecov
old_version: 0.6.4
new_version: 0.13.0
source: https://github.com/colszowka/simplecov/

gem: rspec
old_version: 2.11.0
new_version: 3.5.0
source: https://github.com/rspec/rspec
diff: [http://github.com/rspec/rspec/compare/v2.11.0...v3.5.0](http://github.com/rspec/rspec/compare/v2.11.0...v3.5.0)
